### PR TITLE
Phraseanet - Specify user/group id when needed

### DIFF
--- a/charts/phraseanet/Chart.yaml
+++ b/charts/phraseanet/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.11.0
+version: 0.12.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/phraseanet/templates/rabbitmq.yml
+++ b/charts/phraseanet/templates/rabbitmq.yml
@@ -34,6 +34,15 @@ spec:
         volumeMounts:
         - name: data
           mountPath: "/var/lib/rabbitmq"
+        {{- if or .Values.rabbitmq.runAsUser .Values.rabbitmq.runAsGroup }}
+        securityContext:
+          {{- if .Values.rabbitmq.runAsUser }}
+          runAsUser: {{ .Values.rabbitmq.runAsUser }}
+          {{- end }}
+          {{- if .Values.rabbitmq.runAsGroup }}
+          runAsGroup: {{ .Values.rabbitmq.runAsGroup }}
+          {{- end }}
+        {{- end }}
         env:
         - name: RABBITMQ_DEFAULT_USER
           value: {{ tpl .Values.rabbitmq.default_user $ | quote }}

--- a/charts/phraseanet/values.yaml
+++ b/charts/phraseanet/values.yaml
@@ -65,6 +65,8 @@ rabbitmq:
   default_vhost: "{{ .Values.app.phraseanet_rabbitmq_vhost }}"
   node_name: rabbit@rabbitmq
   heartbeat: 60
+  runAsUser:
+  runAsGroup:
   persistence:
     enabled: true
     existingClaim:


### PR DESCRIPTION
## Description

This change fixes the issue of `chown: /var/lib/rabbitmq: Operation not permitted` errors when RabbitMQ is started. It looks like RabbitMQ has a [hardcoded UID/GID of 999](https://github.com/docker-library/rabbitmq/blob/96b94da11728354a96fc1af0aadb2799ef0fd94f/3.10/ubuntu/Dockerfile#L188) which doesn't work with some NFS mounted with a UID/GID of 1000 for example. The proposed change avoids this error and allows RabbitMQ to launch correctly.